### PR TITLE
 `Tuist` 로 생성된 프로젝트의 `Launch Screen` 이 `Full Screen` 으로 나오지 않는 문제를 수정합니다.

### DIFF
--- a/Project/GithubSearch/Supporting Files/Info.plist
+++ b/Project/GithubSearch/Supporting Files/Info.plist
@@ -2,14 +2,14 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-  <key>CFBundleIdentifier</key>
-  <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
-  <key>CFBundleVersion</key>
-  <string>1</string>
-  <key>CFBundleShortVersionString</key>
-  <string>1.0</string>
-  <key>CFBundleExecutable</key>
-  <string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -25,6 +25,11 @@
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>
 		<true/>
+	</dict>
+	<key>UILaunchScreen</key>
+	<dict>
+		<key>UIImageName</key>
+		<string></string>
 	</dict>
 </dict>
 </plist>


### PR DESCRIPTION
## 배경
- `Tuist` 로 최소 설정으로 생성된 프로젝트에서 `Launch Screen` 이 풀화면으로 보이지 않는 문제를 해결해 봅니다.

## 작업내용
- `Info.plist` 에 `UILaunchScreen` 설정 값을 추가하였습니다.

## 스크린샷

![Simulator Screen Shot - iPhone 13 Pro - 2022-01-30 at 04 15 32](https://user-images.githubusercontent.com/360568/151674457-586a2fc8-c1de-45ac-9682-16366cdce1a9.png)

