### PR TITLE
네트워크 모듈을 추가합니다.

### DIFF
--- a/GithubSearchTests/Network/GithubSearchTests.swift
+++ b/GithubSearchTests/Network/GithubSearchTests.swift
@@ -1,0 +1,49 @@
+//
+//  GithubSearchTests.swift
+//  GithubSearchTests
+//
+//  Created by SungHak Jung on 2022/01/31.
+//  Copyright © 2022 GenithLabs. All rights reserved.
+//
+
+import XCTest
+import Combine
+import GithubSearch
+
+class GithubSearchTests: XCTestCase {
+  private func createNetworking() -> Networking {
+    return Networking()
+  }
+
+  override func setUpWithError() throws {
+    // Put setup code here. This method is called before the invocation of each test method in the class.
+  }
+
+  override func tearDownWithError() throws {
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+  }
+
+  func test_GithubServiceUser() throws {
+    // given
+    let expectation = XCTestExpectation(description: "Fetch Users")
+    let networking = self.createNetworking()
+    let githubService = GithubService(networking: networking)
+    var bag = Set<AnyCancellable>()
+
+    // when
+    _ = githubService.users().sink(receiveCompletion: { _ in}) { data in
+      // then
+        XCTAssertTrue(!data.isEmpty)
+        expectation.fulfill()
+      }.store(in: &bag)
+
+    wait(for: [expectation], timeout: 3)
+  }
+
+  func testPerformanceExample() throws {
+    // This is an example of a performance test case.
+    measure {
+      // Put the code you want to measure the time of here.
+    }
+  }
+}

--- a/Project/GithubSearch/Sources/Network/API/API.swift
+++ b/Project/GithubSearch/Sources/Network/API/API.swift
@@ -1,0 +1,26 @@
+//
+//  API.swift
+//  GithubSearch
+//
+//  Created by SungHak Jung on 2021/12/30.
+//
+
+import Foundation
+
+public protocol API {
+  var url: URL { get }
+  var route: Route { get }
+  var targetRequest: URLRequest { get }
+}
+
+public extension API {
+  var defaultURL: URL {
+    return URL(string: "http://hakburi.synology.me")! // Change your default API domain
+  }
+
+  var targetRequest: URLRequest {
+    var request: URLRequest = URLRequest(url: self.url)
+    request.httpMethod = self.route.method.rawValue
+    return request
+  }
+}

--- a/Project/GithubSearch/Sources/Network/API/Method.swift
+++ b/Project/GithubSearch/Sources/Network/API/Method.swift
@@ -1,0 +1,14 @@
+//
+//  Method.swift
+//  GithubSearch
+//
+//  Created by SungHak Jung on 2021/12/31.
+//
+
+public enum Method: String {
+  case get
+  case post
+  case put
+  case delete
+  case patch
+}

--- a/Project/GithubSearch/Sources/Network/API/Route.swift
+++ b/Project/GithubSearch/Sources/Network/API/Route.swift
@@ -1,0 +1,34 @@
+//
+//  Route.swift
+//  GithubSearch
+//
+//  Created by SungHak Jung on 2021/12/31.
+//
+
+public enum Route {
+  case get(String)
+  case post(String)
+  case put(String)
+  case delete(String)
+  case patch(String)
+
+  public var uri: String {
+    switch self {
+    case .get(let uri): return uri
+    case .post(let uri): return uri
+    case .put(let uri): return uri
+    case .delete(let uri): return uri
+    case .patch(let uri): return uri
+    }
+  }
+
+  public var method: Method {
+    switch self {
+    case .get: return .get
+    case .post: return .post
+    case .put: return .put
+    case .delete: return .delete
+    case .patch: return .patch
+    }
+  }
+}

--- a/Project/GithubSearch/Sources/Network/Networking.swift
+++ b/Project/GithubSearch/Sources/Network/Networking.swift
@@ -1,0 +1,29 @@
+//
+//  Networking.swift
+//  GithubSearch
+//
+//  Created by SungHak Jung on 2021/12/13.
+//
+
+import Foundation
+import Combine
+
+public protocol NetworkingProtocol {
+  func request(_ targetAPI: API) -> AnyPublisher<Data, Error>
+}
+
+public final class Networking: NetworkingProtocol {
+  public init() {}
+  
+  public func request(_ targetAPI: API) -> AnyPublisher<Data, Error> {
+    return URLSession.shared.dataTaskPublisher(for: targetAPI.targetRequest)
+			.tryMap { data, response -> Data in
+				guard let httpResponse = response as? HTTPURLResponse, 200..<300 ~= httpResponse.statusCode else {
+					throw URLError(.badServerResponse)
+				}
+				return data
+			}
+			.mapError { $0 }
+			.eraseToAnyPublisher()
+	}
+}

--- a/Project/GithubSearch/Sources/Network/ServiceAPI/GithubAPI.swift
+++ b/Project/GithubSearch/Sources/Network/ServiceAPI/GithubAPI.swift
@@ -1,0 +1,29 @@
+//
+//  GithubAPI.swift
+//  GithubSearch
+//
+//  Created by SungHak Jung on 2021/12/31.
+//
+
+import Foundation
+
+public enum GithubAPI {
+  case user // FIXME: 테스트용 삭제 필요!
+}
+
+extension GithubAPI: API {
+  public var domain: String {
+    return "http://hakburi.synology.me"
+  }
+
+  public var url: URL {
+    return URL(string: self.domain + self.route.uri) ?? self.defaultURL
+  }
+
+  public var route: Route {
+    switch self {
+    case .user:
+      return .get("/json/users.php")
+    }
+  }
+}

--- a/Project/GithubSearch/Sources/Service/GithubService.swift
+++ b/Project/GithubSearch/Sources/Service/GithubService.swift
@@ -1,0 +1,25 @@
+//
+//  GithubService.swift
+//  GithubSearch
+//
+//  Created by SungHak Jung on 2021/12/31.
+//
+
+import Foundation
+import Combine
+
+public protocol GithubServiceProtocol {
+  func users() -> AnyPublisher<Data, Error>
+}
+
+public final class GithubService: GithubServiceProtocol {
+  let networking: Networking
+
+  public init(networking: Networking) {
+    self.networking = networking
+  }
+
+  public func users() -> AnyPublisher<Data, Error> {
+    return self.networking.request(GithubAPI.user)
+  }
+}


### PR DESCRIPTION
## 배경
- `HTTP` 통신을 위한 `Networking` 모듈이 필요합니다.

## 작업내용
- `HTTP Method` 케이스를 정의합니다.
- `API`  의 각 `Method` 의 `endpoint URI` 을 연과값으로 받는 `Route` 라는 `enum case` 를 작성합니다.
- `URLRequest  를 생성하는 `API` 프로토콜을 작성합니다.
- `Combine` 기반 `Networking`  클래스를 생성합니다.
- 비지니스 로직에 필요한 `GithubAPI`  와 `GithubService` 를 작성합니다.
- `GithubService` 의 첫 테스트 케이스르 작성합니다. (WIP)